### PR TITLE
feat(server): add register http, tcp, icmp

### DIFF
--- a/internal/command/monitor/register.go
+++ b/internal/command/monitor/register.go
@@ -60,9 +60,9 @@ func (c Register) domain(ctx *appcontext.AppContext, checkData *modelresponse.Ch
 		return "", err
 	}
 
-	// check domain is existed or not
+	// check target is existed or not
 	if monitorSvc.IsTargetExisted(ctx, mongodb.MonitorTypeDomain, checkData.Name, user.ID) {
-		return "", fmt.Errorf("domain %s is already registered", checkData.Name)
+		return "", fmt.Errorf("target %s is already registered", checkData.Name)
 	}
 
 	// create monitor
@@ -71,17 +71,83 @@ func (c Register) domain(ctx *appcontext.AppContext, checkData *modelresponse.Ch
 		return "", err
 	}
 
-	return fmt.Sprintf("domain `%s` has been successfully registered with id `%s`", checkData.Name, strings.ToUpper(doc.Code)), nil
+	return fmt.Sprintf("target `%s` has been successfully registered with id `%s`", checkData.Name, strings.ToUpper(doc.Code)), nil
 }
 
-func (Register) http(_ *appcontext.AppContext, checkData *modelresponse.Check) (string, error) {
-	return "", nil
+func (c Register) http(ctx *appcontext.AppContext, checkData *modelresponse.Check) (string, error) {
+	var (
+		userSvc    = service.User{}
+		monitorSvc = service.Monitor{}
+	)
+
+	// find user first
+	user, err := userSvc.FindOrCreateWithPlatformID(ctx, c.Platform, c.ChatID, c.User)
+	if err != nil {
+		return "", err
+	}
+
+	// check target is existed or not
+	if monitorSvc.IsTargetExisted(ctx, mongodb.MonitorTypeHTTP, checkData.Name, user.ID) {
+		return "", fmt.Errorf("target %s is already registered", checkData.Name)
+	}
+
+	// create monitor
+	doc, err := monitorSvc.CreateHTTP(ctx, checkData.Name, user.ID)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("target `%s` has been successfully registered with id `%s`", checkData.Name, strings.ToUpper(doc.Code)), nil
 }
 
-func (Register) tcp(_ *appcontext.AppContext, checkData *modelresponse.Check) (string, error) {
-	return "", nil
+func (c Register) tcp(ctx *appcontext.AppContext, checkData *modelresponse.Check) (string, error) {
+	var (
+		userSvc    = service.User{}
+		monitorSvc = service.Monitor{}
+	)
+
+	// find user first
+	user, err := userSvc.FindOrCreateWithPlatformID(ctx, c.Platform, c.ChatID, c.User)
+	if err != nil {
+		return "", err
+	}
+
+	// check target is existed or not
+	if monitorSvc.IsTargetExisted(ctx, mongodb.MonitorTypeTCP, checkData.Name, user.ID) {
+		return "", fmt.Errorf("target %s is already registered", checkData.Name)
+	}
+
+	// create monitor
+	doc, err := monitorSvc.CreateTCP(ctx, checkData.Name, user.ID)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("target `%s` has been successfully registered with id `%s`", checkData.Name, strings.ToUpper(doc.Code)), nil
 }
 
-func (Register) icmp(_ *appcontext.AppContext, checkData *modelresponse.Check) (string, error) {
-	return "", nil
+func (c Register) icmp(ctx *appcontext.AppContext, checkData *modelresponse.Check) (string, error) {
+	var (
+		userSvc    = service.User{}
+		monitorSvc = service.Monitor{}
+	)
+
+	// find user first
+	user, err := userSvc.FindOrCreateWithPlatformID(ctx, c.Platform, c.ChatID, c.User)
+	if err != nil {
+		return "", err
+	}
+
+	// check target is existed or not
+	if monitorSvc.IsTargetExisted(ctx, mongodb.MonitorTypeICMP, checkData.Name, user.ID) {
+		return "", fmt.Errorf("target %s is already registered", checkData.Name)
+	}
+
+	// create monitor
+	doc, err := monitorSvc.CreateICMP(ctx, checkData.Name, user.ID)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("target `%s` has been successfully registered with id `%s`", checkData.Name, strings.ToUpper(doc.Code)), nil
 }

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -8,6 +8,8 @@ func Init() {
 	)
 
 	monitor := Monitor{}
+	monitor.setup(q, monitorCheck.interval30Seconds)
+	q.Server.HandleFunc(monitorCheck.interval30Seconds.Task, monitor.check)
 	monitor.setup(q, monitorCheck.interval60Seconds)
 	q.Server.HandleFunc(monitorCheck.interval60Seconds.Task, monitor.check)
 }

--- a/internal/service/monitor.go
+++ b/internal/service/monitor.go
@@ -101,22 +101,80 @@ func (s Monitor) CreateDomain(ctx *appcontext.AppContext, domain, scheme string,
 	return &doc, nil
 }
 
-func (Monitor) UpdateJobID(ctx *appcontext.AppContext, monitorID primitive.ObjectID, jobID string, interval int) error {
-	span := sentryio.NewSpan(ctx.Context, "[service][monitor] update job id")
+func (s Monitor) CreateHTTP(ctx *appcontext.AppContext, http string, ownerID primitive.ObjectID) (*mongodb.Monitor, error) {
+	span := sentryio.NewSpan(ctx.Context, "[service][monitor] create http")
 	defer span.Finish()
 
 	var (
-		d      = dao.Monitor{}
-		filter = bson.M{
-			"_id": monitorID,
-		}
-		updateData = bson.M{
-			"$set": bson.M{
-				"job.id":       jobID,
-				"job.interval": interval,
-			},
-		}
+		d    = dao.Monitor{}
+		code = s.randomCode(ctx, ownerID)
 	)
 
-	return d.UpdateOneByCondition(ctx, filter, updateData)
+	var doc = mongodb.Monitor{
+		ID:        mongodb.NewObjectID(),
+		Owner:     ownerID,
+		Code:      code,
+		Target:    http,
+		Type:      mongodb.MonitorTypeHTTP,
+		Interval:  mongodb.MonitorInterval30Seconds,
+		CreatedAt: time.Now(),
+	}
+
+	if err := d.InsertOne(ctx, doc); err != nil {
+		return nil, err
+	}
+
+	return &doc, nil
+}
+
+func (s Monitor) CreateTCP(ctx *appcontext.AppContext, tcp string, ownerID primitive.ObjectID) (*mongodb.Monitor, error) {
+	span := sentryio.NewSpan(ctx.Context, "[service][monitor] create tcp")
+	defer span.Finish()
+
+	var (
+		d    = dao.Monitor{}
+		code = s.randomCode(ctx, ownerID)
+	)
+
+	var doc = mongodb.Monitor{
+		ID:        mongodb.NewObjectID(),
+		Owner:     ownerID,
+		Code:      code,
+		Target:    tcp,
+		Type:      mongodb.MonitorTypeTCP,
+		Interval:  mongodb.MonitorInterval60Seconds,
+		CreatedAt: time.Now(),
+	}
+
+	if err := d.InsertOne(ctx, doc); err != nil {
+		return nil, err
+	}
+
+	return &doc, nil
+}
+
+func (s Monitor) CreateICMP(ctx *appcontext.AppContext, icmp string, ownerID primitive.ObjectID) (*mongodb.Monitor, error) {
+	span := sentryio.NewSpan(ctx.Context, "[service][monitor] create icmp")
+	defer span.Finish()
+
+	var (
+		d    = dao.Monitor{}
+		code = s.randomCode(ctx, ownerID)
+	)
+
+	var doc = mongodb.Monitor{
+		ID:        mongodb.NewObjectID(),
+		Owner:     ownerID,
+		Code:      code,
+		Target:    icmp,
+		Type:      mongodb.MonitorTypeICMP,
+		Interval:  mongodb.MonitorInterval60Seconds,
+		CreatedAt: time.Now(),
+	}
+
+	if err := d.InsertOne(ctx, doc); err != nil {
+		return nil, err
+	}
+
+	return &doc, nil
 }


### PR DESCRIPTION
## **Type**
enhancement, bug_fix


___

## **Description**
- Implemented registration logic for HTTP, TCP, and ICMP monitors, allowing users to register these types of monitors.
- Introduced a new 30 seconds interval for monitor checks and added Sentry transactions for better error tracking.
- Improved ICMP check by setting a timeout and handling cases where the target is unreachable.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>register.go</strong><dd><code>Implement Registration Logic for HTTP, TCP, and ICMP Monitors</code>&nbsp; &nbsp; </dd></summary>
<hr>

internal/command/monitor/register.go
<li>Changed error message from "domain is already registered" to "target <br>is already registered".<br> <li> Implemented registration logic for HTTP, TCP, and ICMP monitors.


</details>
    

  </td>
  <td><a href="https://github.com/namhq1989/maid-bots/pull/11/files#diff-6d04b9fbb9e40afe3db99df8865bdc2ea9098fc7ad6fd2b508a6d7664ffc2bd5">+75/-9</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>job.go</strong><dd><code>Add 30 Seconds Interval Monitor Check Setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/job/job.go
<li>Added setup and handler function call for a new 30 seconds monitor <br>check interval.


</details>
    

  </td>
  <td><a href="https://github.com/namhq1989/maid-bots/pull/11/files#diff-4c88bdca4f96948ab450d1be9f712310158625429786f4c8c1361842e6eecf91">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>monitor.go</strong><dd><code>Introduce 30 Seconds Interval and Sentry Transactions for Monitor <br>Checks</code></dd></summary>
<hr>

internal/job/monitor.go
<li>Introduced a new 30 seconds interval for monitor checks.<br> <li> Added Sentry transaction for monitor check tasks.


</details>
    

  </td>
  <td><a href="https://github.com/namhq1989/maid-bots/pull/11/files#diff-6b1e5f3caf824a427233aa9b27ff0e49a200e2e71d7e23f9017a857a11ea32bb">+14/-1</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>monitor.go</strong><dd><code>Add Creation Functions for HTTP, TCP, and ICMP Monitors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/service/monitor.go
<li>Added functions to create HTTP, TCP, and ICMP monitors.<br> <li> Utilized Sentry spans for new monitor creation functions.


</details>
    

  </td>
  <td><a href="https://github.com/namhq1989/maid-bots/pull/11/files#diff-a65d564644992e4029928f6cd17cfc86dfc9f5df251bd6b53dc96a43b740b824">+71/-13</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>icmp.go</strong><dd><code>Improve ICMP Check with Timeout and Unreachable Target Handling</code></dd></summary>
<hr>

util/netinspect/icmp.go
<li>Set a timeout for ICMP pinger.<br> <li> Added error handling for 100% packet loss indicating target <br>unreachable.


</details>
    

  </td>
  <td><a href="https://github.com/namhq1989/maid-bots/pull/11/files#diff-d6c5a1a159df1603dffe87d18536439fc78782ab86efac001bb3b57b60387257">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
